### PR TITLE
Add bolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 ## HTTP
 *Libraries for working with HTTP and scraping websites.*
 
+* [bolt](https://github.com/SebastianSzturo/bolt) - Simple and fast http proxy.
 * [cauldron](https://github.com/meh/cauldron) - An HTTP/SPDY server as a library.
 * [exvcr](https://github.com/parroty/exvcr) - HTTP request/response recording library for Elixir, inspired by VCR.
 * [http](https://github.com/slogsdon/http) - HTTP server for Elixir.


### PR DESCRIPTION
A small project of mine, that we are using in production.

Bolt is a simple and fast web proxy living in the Erlang VM. Bolt can be used as a ssl proxy to prevent mixed content warnings on secure pages or to bypass CORS. For example as a SSL image proxy or for client side website scraping.