### PR TITLE
Removing broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,6 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 *Web development frameworks.*
 
 * [clint](https://github.com/lpil/clint) - An Elixir web micro-framework, inspired by Sinatra, built on top of Plug and Cowboy.
-* [exelli](https://github.com/pigmej/exelli) - An Elli Elixir wrapper with some sugar sytnax goodies.
 * [phoenix](https://github.com/phoenixframework/phoenix) - Elixir Web Framework targeting full-featured, fault tolerant applications with realtime functionality.
 * [placid](https://github.com/slogsdon/placid) - A REST toolkit for building highly-scalable and fault-tolerant HTTP APIs with Elixir.
 * [relax](https://github.com/AgilionApps/relax) - Simple Elixir implementation of a [jsonapi.org](http://jsonapi.org) server.


### PR DESCRIPTION
It's seems the project was removed/or/moved (https://github.com/pigmej/exelli)