### PR TITLE
Added database_url to ORM/Data Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [atlas](https://github.com/chrismccord/atlas) - Object Relational Mapper for Elixir.
 * [boltun](https://github.com/briksoftware/boltun) - Transforms notifications from the Postgres LISTEN/NOTIFY mechanism into callback execution.
 * [craterl](https://github.com/crate/craterl) - Erlang client for crate.
+* [database_url](https://github.com/s-m-i-t-a/database_url) - Parse database URL and return keyword list for use with Ecto.
 * [datomex](https://github.com/edubkendo/datomex) - Elixir driver for the Datomic REST API.
 * [dexts](https://github.com/meh/dexts) - Disk Elixir Terms Storage, dest wrapper.
 * [diver](https://github.com/novabyte/diver) - A HBase driver for Erlang/Elixir using Jinterface and the Asynchbase Java client to query the database.


### PR DESCRIPTION
Hi @h4cc, here is another PR for you.  This one adds `database_url` to the "ORM and Data Mapping" section.  There were a few non-ORM libraries in there already so I concluded this was probably the right place for it, let me know if you'd like me to move it elsewhere.

Closes #621 