### PR TITLE
Add Exstagram, Instagram API library for Elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,6 +792,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [exgrid](https://github.com/bradleyd/exgrid) - interact with Sendgrid's API.
 * [exjira](https://github.com/mattweldon/exjira) - JIRA client library for Elixir.
 * [exlingr](https://github.com/mtwtkman/exlingr) - A Lingr client module.
+* [exstagram](https://github.com/arthurcolle/exstagram) - Elixir library for Instagram v1 API.
 * [extwitter](https://github.com/parroty/extwitter) - Twitter client library for Elixir.
 * [exurban](https://github.com/tappsi/exurban) - Elixir wrapper for UrbanAirship API.
 * [facebook](https://github.com/mweibel/facebook.ex) - Facebook Graph API Wrapper written in Elixir.


### PR DESCRIPTION
Hello, I built a very simple Instagram API wrapper library that currently only supports "/user_recent_media" on their API endpoint and will be adding the remainder of the API shortly but I also wrote pretty good usage documentation for it (see https://github.com/arthurcolle/exstagram), as well as created an example Phoenix app demonstrating it in the wild: https://exstagram-example.herokuapp.com

I hope some find it useful! 