### PR TITLE
Update description for calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 *Libraries for working with dates and times.*
 
 * [block_timer](https://github.com/adamkittelson/block_timer) - Macros to use :timer.apply_after and :timer.apply_interval with a block.
-* [calendar](https://github.com/lau/calendar) - Calendar is a date and time library for Elixir. The only Elixir library with with accurate, up-to-date time zone information.
+* [calendar](https://github.com/lau/calendar) - Calendar is a date and time library for Elixir.
 * [chronos](https://github.com/nurugger07/chronos) - An Elixir date/time library.
 * [good_times](https://github.com/magplus/good_times) - Expressive and easy to use datetime functions.
 * [milliseconds](https://github.com/davebryson/elixir_milliseconds) - Simple library to work with milliseconds in Elixir.


### PR DESCRIPTION
While `calendar` was previously the only library with a correct timezone implementation, `timex` does now as well. In order to prevent confusion around this, I requested that lau update his README (which he graciously has already done), and I'm reflecting that change here as well for those shopping around for a date/time library to use.

/cc @lau