### PR TITLE
add alchemist-server to editor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@ Various resources, such as books, websites and articles, for improving your Elix
 *Editors and IDEs useable for Elixir/Erlang*
 
 * [Alchemist](https://github.com/tonini/alchemist.el) - Elixir Tooling Integration Into Emacs.
+* [Alchemist-Server](https://github.com/tonini/alchemist-server) - Editor/IDE independent background server to inform about Elixir mix projects.
 * [Atom](https://atom.io/packages/language-elixir) - Elixir language support for Atom.
 * [atom-iex](https://github.com/indiejames/atom-iex) - Run an IEx session in Atom.
 * [intellij_elixir](https://github.com/KronicDeth/intellij_elixir) - Elixir helpers for intellj-elixir, the Elixir plugin for JetBrains IDEs.


### PR DESCRIPTION
Hi,

I separated the Alchemist-Server from the Alchemist project so that other Editor Elixir package developers could maybe use it too.

Cheers

Samuel