### PR TITLE
Marking Hyperledger as no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 
 * [bpe](https://github.com/spawnproc/bpe) - Business Process Engine in Erlang.
 * [dragonfly_server](https://github.com/cloud8421/dragonfly-server) - Elixir app to serve Dragonfly images.
-* [hyperledger](https://github.com/hyperledger/hyperledger-server) - Reference server for the Hyperledger protocol.
+* [hyperledger](https://github.com/hyperledger/hyperledger-server) - (No Longer Maintained) Reference server for the Hyperledger protocol.
 * [majremind](https://bitbucket.org/Anwen/majremind) - A self-maintained database of your updated server which tells you which one needs to be updated. .
 * [n2o](https://github.com/5HT/n2o) - WebSocket Application Server.
 * [poxa](https://github.com/edgurgel/poxa) - Open Pusher implementation, compatible with Pusher libraries.


### PR DESCRIPTION
Project is fresh for now but will most likely fall behind if not maintained.

Is there a better way to mark this project as not being maintained?