### PR TITLE
Removing good_times from Date and Time section

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,6 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [block_timer](https://github.com/adamkittelson/block_timer) - Macros to use :timer.apply_after and :timer.apply_interval with a block.
 * [calendar](https://github.com/lau/calendar) - Calendar is a date and time library for Elixir.
 * [chronos](https://github.com/nurugger07/chronos) - An Elixir date/time library.
-* [good_times](https://github.com/magplus/good_times) - Expressive and easy to use datetime functions.
 * [milliseconds](https://github.com/davebryson/elixir_milliseconds) - Simple library to work with milliseconds in Elixir.
 * [moment](https://github.com/atabary/moment) - Parse, validate, manipulate, and display dates in Elixir.
 * [quantum](https://github.com/c-rack/quantum-elixir) - Cron-like job scheduler for Elixir applications.


### PR DESCRIPTION
good_times datetime lib is 404ing on github currently.

https://github.com/magplus/good_times