### PR TITLE
Removing Phoenix Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,6 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [http_router](https://github.com/slogsdon/elixir-http-router) - HTTP Router with various macros to assist in developing your application and organizing your code.
 * [passport](https://github.com/opendrops/passport) - Passport provides authentication for Phoenix applications.
 * [phoenix_ecto](https://github.com/phoenixframework/phoenix_ecto) - Phoenix and Ecto integration.
-* [phoenix_generator](https://github.com/etufe/phoenix_generator) - Generate boilerplate for Phoenix applications.
 * [phoenix_html](https://github.com/phoenixframework/phoenix_html) - Phoenix.HTML functions for working with HTML strings and templates.
 * [phoenix_html_sanitizer](https://github.com/elixirstatus/phoenix_html_sanitizer) - HTML Sanitizer integration for Phoenix.
 * [phoenix_linguist](https://github.com/jxs/phoenix_linguist) - A project that integrates Phoenix with Linguist, providing a plug and view helpers.


### PR DESCRIPTION
Phoenix Generator is no longer being maintained by the owner and most of this libs functionality has been rolled into Phoenix at this point.

**Note from Owner**
DEPRECATED: The functionality of these generators is now mostly built into Phoneix and the rest have not been updated in quite some time!

https://github.com/etufe/phoenix_generator