### PR TITLE
Includes Guri to the Networking list

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [ejabberd](https://github.com/processone/ejabberd) - Robust, ubiquitous and massively scalable Jabber/XMPP Instant Messaging platform.
 * [ExIrc](https://github.com/bitwalker/exirc) - IRC client adapter for Elixir projects.
 * [ExPcap](https://github.com/cobenian/expcap) - PCAP parser written in Elixir.
+* [Guri](https://github.com/elvio/guri) - Automate tasks using chat messages.
 * [hedwig](https://github.com/scrogson/hedwig) - XMPP Client/Bot Framework for Elixir.
 * [kaguya](https://github.com/Luminarys/Kaguya) - A small, powerful, and modular IRC bot.
 * [pool](https://github.com/slogsdon/pool) - Socket acceptor pool for Elixir.


### PR DESCRIPTION
This commit includes Guri (https://github.com/elvio/guri) to the Networking list.