### PR TITLE
Added ExSentry and fixed link for Honeybadger

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,8 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 ## Logging
 *Logging infos and messages.*
 
-* [honeybadger](https://github.com/honeybadger-io/honeybadger-elixir) - Error logging to [Honeybadger](honeybadger.io).
+* [exsentry](https://github.com/appcues/exsentry) - Error logging to [Sentry](https://getsentry.com/).
+* [honeybadger](https://github.com/honeybadger-io/honeybadger-elixir) - Error logging to [Honeybadger](https://www.honeybadger.io/).
 * [json_logger](https://github.com/LeeroyDing/json_logger) - JSON Logger is a logger backend that outputs elixir logs in JSON format.
 * [lager](https://github.com/basho/lager) - A logging framework for Erlang/OTP by basho.com.
 * [lager_logger](https://github.com/PSPDFKit-labs/lager_logger) - A lager backend that forwards all log messages to Elixir's Logger.


### PR DESCRIPTION
Added the `ExSentry` library to the Logging section.  While I was there, I fixed a broken link for the Honeybadger error logging service.