### PR TITLE
Add Rustler under NIF category

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 *Tools and libraries working with Erlang NIF.*
 
 * [nifty](https://github.com/rossjones/nifty) - Helper script for setting up the boilerplate required when writing a NIF.
+* [Rustler](https://github.com/hansihe/Rustler) - Library for writing NIFs for Erlang or Elixir safely in Rust. No segfaults.
 
 ## Natural Language Processing (NLP)
 *Tools and libraries that work with human (natural) languages.*


### PR DESCRIPTION
I don't think this is strictly allowed, since it's not actually written in elixir, and is nor hex installable. I would argue it's relevant regardless, as it provides specific functionality in order to make Nifs easy and fast to write and use.

If you don't agree, feel free to decline the pull.