### PR TITLE
Removed xoauth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [ueberauth_identity](https://github.com/ueberauth/ueberauth_identity) - A simple username/password strategy for Überauth.
 * [ueberauth_slack](https://github.com/ueberauth/ueberauth_slack) - A Slack strategy for Überauth.
 * [ueberauth_twitter](https://github.com/ueberauth/ueberauth_twitter) - Twitter Strategy for Überauth.
-* [xoauth2](https://github.com/craigp/elixir_xoauth2) - A simple XOAuth2 module for Elixir.
 
 ## Authorization
 *Libraries for implementing Authorization handling.*


### PR DESCRIPTION
I no longer work on this lib, it was just a learning exercise and people are probably better off using https://github.com/parroty/oauth2ex