### PR TITLE
slack_logger_backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [raven](https://github.com/vishnevskiy/raven-elixir) - Elixir client for [Sentry](http://getsentry.com/).
 * [rogger](https://github.com/duartejc/rogger) - Elixir logger to publish log messages in RabbitMQ.
 * [rollbax](https://github.com/elixir-addicts/rollbax) - Exception tracking and logging to [Rollbar](https://rollbar.com/).
+* [slack_logger_backend](https://github.com/craigp/slack_logger_backend) - A logger backend for posting errors to Slack.
 * [syslog](https://github.com/Vagabond/erlang-syslog) - Erlang port driver for interacting with syslog via syslog(3).
 
 ## Macros


### PR DESCRIPTION
A logger backend for posting errors to Slack.