### PR TITLE
Adds Sentinel - a phoenix authentication library

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [scrivener](https://github.com/drewolson/scrivener) - Paginate your Ecto queries.
 * [scrivener_headers](https://github.com/doomspork/scrivener_headers) - Helpers for paginating API responses with Scrivener and HTTP headers.
 * [scrivener_html](https://github.com/mgwidmann/scrivener_html) - Helpers built to work with Scrivener's page struct to easily build HTML output for various CSS frameworks.
+* [sentinel](https://github.com/britton-jb/sentinel) - An authentication framework for Phoenix extending guardian with routing and other basic functionality.
 * [trailing_format_plug](https://github.com/mschae/trailing_format_plug) - An Elixir plug to support legacy APIs that use a rails-like trailing format.
 * [webassembly](https://github.com/herenowcoder/webassembly) - Web DSL for Elixir.
 * [weebo](https://github.com/stevenschobert/weebo) - An XML-RPC parser/formatter for Elixir, with full support for datatype mapping.


### PR DESCRIPTION
Sentinel is a phoenix authentication library that extends [guardian](https://github.com/ueberauth/guardian), adding functionality desired in most applications. https://github.com/h4cc/awesome-elixir/issues/1639