### PR TITLE
Update Bamboo to point to the thoughtbot repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 ## Email
 *Working with Email and stuff.*
 
-* [bamboo](https://github.com/paulcsmith/bamboo) - Flexible and easy to use email for Elixir.
+* [bamboo](https://github.com/thoughtbot/bamboo) - Composable, testable and adapter based email library. Out of the box support for rendering with Phoenix and a plug for previewing sent emails in dev.
 * [echo](https://github.com/zmoshansky/echo) - A meta-notification system; Echo checks notification preferences & dispatches notifications.
 * [gen_smtp](https://github.com/Vagabond/gen_smtp) - A generic Erlang SMTP server and client that can be extended via callback modules.
 * [mail](https://github.com/DockYard/elixir-mail) - An RFC2822 implementation in Elixir, built for composability.


### PR DESCRIPTION
Bamboo has been transferred to the thoughtbot repo. It also updates the description since a lot has changed in the last month.

Thanks again for this awesome resource!