### PR TITLE
Remove duplicate koans

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,6 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [rollex](https://gitlab.com/olhado/rollex) - Elixir library using a Pratt Parser algorithm to calculate dice rolls.
 * [rubix](https://github.com/YellowApple/Rubix) - A very simple (and barely-functioning) Ruby runner for Elixir.
 * [stranger](https://github.com/cazrin/stranger) - Elixir Phoenix app to chat anonymously with a randomly chosen stranger [https://hellostranger.xyz](hellostranger.xyz).
-* [ukutaht elixir-koans](https://github.com/ukutaht/elixir-koans) - Elixir koans is a fun, easy way to get started with the elixir programming language.
 * [weather](https://github.com/tacticiankerala/elixir-weather) - A command line weather app built using Elixir.
 
 ## Feeds


### PR DESCRIPTION
`ukutaht/elixir-koans` and `elixirkoans/elixir-koans` are the same thing, we just recently moved it from my personal account to an organisation.