### PR TITLE
Add Package "ueberauth_auth0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [oauth2ex](https://github.com/parroty/oauth2ex) - Another OAuth 2.0 client library for Elixir.
 * [oauther](https://github.com/lexmag/oauther) - An OAuth 1.0 implementation for Elixir.
 * [ueberauth](https://github.com/ueberauth/ueberauth) - An Elixir Authentication System for Plug-based Web Applications.
+* [ueberauth_auth0](https://hex.pm/packages/ueberauth_auth0) - An Ueberauth strategy for using Auth0 to authenticate your users.
 * [ueberauth_facebook](https://github.com/ueberauth/ueberauth_Facebook) - Facebook OAuth2 Strategy for Überauth.
 * [ueberauth_github](https://github.com/ueberauth/ueberauth_github) - A GitHub strategy for Überauth.
 * [ueberauth_google](https://github.com/ueberauth/ueberauth_google) - A Google strategy for Überauth.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [synthex](https://github.com/bitgamma/synthex) - A signal synthesis library.
 
 ## Authentication
-*Libraries for implementing authentications schemes.*
+*Libraries for implementing authentication schemes.*
 
 * [aeacus](https://github.com/zmoshansky/aeacus) - A simple configurable identity/password authentication module (Compatible with Ecto/Phoenix).
 * [apache_passwd_md5](https://github.com/kevinmontuori/Apache.PasswdMD5) - Apache/APR Style Password Hashing.


### PR DESCRIPTION
Adds the package "ueberauth_auth0" and fixes a typo.