### PR TITLE
added exkanji

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,6 +1175,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 *Libraries providing translations or internationalizations.*
 
 * [ecto_gettext](https://github.com/exbugs-elixir/ecto_gettext) - Library for localization Ecto validation errors with using Gettext.
+* [exkanji](https://github.com/ikeikeikeike/exkanji) - A Elixir library for translating between hiragana, katakana, romaji and kanji. It uses Mecab.
 * [exromaji](https://github.com/ikeikeikeike/exromaji) - A Elixir library for translating between hiragana, katakana and romaji.
 * [linguist](https://github.com/chrismccord/linguist) - Elixir Internationalization library.
 * [parabaikElixirConverter](https://github.com/Arkar-Aung/ParabaikElixirConverter) - ParabaikElixirConverter is just a Elixir version of Parabaik converter. It can convert from Unicode to Zawgyi-One and Zawgyi-One to Unicode vice versa.


### PR DESCRIPTION
I was separating this:https://github.com/h4cc/awesome-elixir/pull/2302

- exkanji - A Elixir library for translating between hiragana, katakana, romaji and kanji. It uses Mecab.

Thanks.
