### PR TITLE
Add Package ex_gecko

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [elixtagram](https://github.com/zensavona/elixtagram) - Instagram API client for Elixir.
 * [everex](https://github.com/jwarlander/everex) - Evernote API client for Elixir.
 * [everyoneapi](https://github.com/knewter/everyoneapi) - API Client for EveryoneAPI.com.
+* [ex_gecko](https://github.com/Brightergy/ex_gecko) - Elixir SDK to communicate with Geckoboard's API.
 * [ex_statsd](https://github.com/CargoSense/ex_statsd) - A statsd client implementation for Elixir.
 * [ex_twilio](https://github.com/danielberkompas/ex_twilio) - Twilio API client for Elixir.
 * [ex_twiml](https://github.com/danielberkompas/ex_twiml) - Generate TwiML for your Twilio integration, right inside Elixir.


### PR DESCRIPTION
ex_gecko is an elixir client that communicates with Geckoboard API. It supports new dataset API and push to widgets API.