### PR TITLE
Added "ecto_autoslug_field" to Misc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [Countries](https://github.com/SebastianSzturo/countries) - Countries is a collection of all sorts of useful information for every country in the ISO 3166 standard.
 * [dye](https://github.com/Kabie/dye) - A library for dyeing your terminal output.
 * [dynamic_compile](https://github.com/okeuday/dynamic_compile) - Compile and load Erlang modules from string input.
+* [ecto_autoslug_field](https://github.com/sobolevn/ecto_autoslug_field) - Automatically creates slugs for your Ecto models.
 * [egaugex](https://github.com/Brightergy/egaugex) - Client to fetch and parse realtime data from egauge devices.
 * [erlang_term](https://github.com/okeuday/erlang_term) - Provide the in-memory size of Erlang terms, ignoring where these are stored.
 * [ex2ms](https://github.com/ericmj/ex2ms) - Translates Elixir functions to match specifications for use with `ets`.


### PR DESCRIPTION
Make sure you have the following format

## Title

Added [ecto_autoslug_field](https://github.com/sobolevn/ecto_autoslug_field)

## Description

Automatically creates slugs for your Ecto models.

