### PR TITLE
Added 'sizeable' library to Files & Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [librex](https://github.com/ricn/librex) - Elixir library to convert office documents to other formats using LibreOffice.
 * [Radpath](https://github.com/lowks/Radpath) - Path library for Elixir, inspired by Python's Enhpath.
 * [sentix](https://github.com/zackehh/sentix) - A cross-platform file watcher for Elixir based on fswatch.
+* [sizeable](https://github.com/arvidkahl/sizeable) - An Elixir library to make file sizes human-readable.
 * [zarex](https://github.com/ricn/zarex) - Filename sanitization for Elixir.
 
 ## Formulars


### PR DESCRIPTION
Added 'sizeable' library to Files & Directories. It's on hex.pm, has 100% test coverage with 28 unit tests. Also, we use it in production ;) It's pretty much a no-nonsense port of `filesize.js` from the node ecosystem. 

It's located at [arvidkahl/sizeable](https://github.com/arvidkahl/sizeable).