### PR TITLE
Add `addict` to the list of authentication libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 *Libraries for implementing authentication schemes.*
 
 * [aeacus](https://github.com/zmoshansky/aeacus) - A simple configurable identity/password authentication module (Compatible with Ecto/Phoenix).
+* [addict](https://github.com/trenpixster/addict) - A user management lib for Phoenix Framework.
 * [apache_passwd_md5](https://github.com/kevinmontuori/Apache.PasswdMD5) - Apache/APR Style Password Hashing.
 * [aws_auth](https://github.com/bryanjos/aws_auth) - AWS Signature Version 4 Signing Library for Elixir.
 * [blackbook](https://github.com/bigmachine-io/blackbook) - All-in-one membership/authentication system for Elixir.


### PR DESCRIPTION
I didn't create a ticket for this but would like to add `trenpixster\addict` package to the authentication library list.
