### PR TITLE
move simple bayes from algorithms to artificial intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [rendezvous](https://github.com/timdeputter/Rendezvous) - Implementation of the Rendezvous or Highest Random Weight (HRW) hashing algorithm in Elixir.
 * [sfmt](https://github.com/jj1bdx/sfmt-erlang/) - SIMD-oriented Fast Mersenne Twister (SFMT) for Erlang.
 * [simhash](https://github.com/UniversalAvenue/simhash-ex) - Simhash implementation using Siphash and N-grams.
-* [simple_bayes](https://github.com/fredwu/simple_bayes) - A Simple Bayes / Naive Bayes implementation in Elixir.
 * [sorted_set](https://github.com/SenecaSystems/sorted_set) - Sorted Sets for Elixir.
 * [spacesaving](https://github.com/rozap/spacesaving) - stream count distinct element estimation using the "space saving" algorithm.
 * [structurez](https://github.com/hamiltop/structurez) - A playground for data structures in Elixir.
@@ -196,6 +195,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 
 * [Exnn](https://github.com/zampino/exnn) - Evolutive Neural Networks framework à la G.Sher written in Elixir.
 * [Neat-Ex](https://gitlab.com/onnoowl/Neat-Ex) - An Elixir implementation of the NEAT algorithm.
+* [simple_bayes](https://github.com/fredwu/simple_bayes) - A Simple Bayes / Naive Bayes implementation in Elixir.
 
 ## Audio and Sounds
 *Libraries working with sounds and tones.*


### PR DESCRIPTION

Sorry for not following the PR format.
In this case I'm not adding a new package but changing the place of one.
`Simple bayes` implements one of the simplest machine learning techniques.

It was classify as "algorithm", sure it is an algorithm but as we have an `Artificial intelligence` section, it should go there. 
