### PR TITLE
Add Package "smoothie"

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [mailibex](https://github.com/awetzel/mailibex) - Library containing Email-related implementations in Elixir: dkim, spf, dmark, mimemail, smtp.
 * [mailman](https://github.com/kamilc/mailman) - Mailman provides a clean way of defining mailers in your Elixir applications.
 * [pop3mail](https://hex.pm/packages/pop3mail) - Pop3 client to download email (including attachments) from the inbox via the commandline or Elixir API.
+* [smoothie](https://github.com/jfrolich/smoothie) - Smoothie inline styles of your email templates, and generates a plain text version from the HTML.
 * [swoosh](https://github.com/swoosh/swoosh) - Compose, deliver and test your Emails easily in Elixir with adapters for SMTP, Sendgrid, Mandrill, Mailgun, Postmark and Phoenix integration with mailbox preview.
 
 ## Embedded Systems


### PR DESCRIPTION
Resolves #2979

Smoothie inline styles of your email templates, and generates a plain text version from the HTML. We extracted this from the codebase at our startup and use it in production. We build this because we couldn't find any library in the ecosystem that provides inlining.