### PR TITLE
Add Package Authorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 ## Authorization
 *Libraries for implementing Authorization handling.*
 
+* [authorize](https://github.com/jfrolich/authorize) - Rule based authorization, for advanced authorization rules
 * [bodyguard](https://github.com/schrockwell/bodyguard) - A flexibile authorization libarary for Phoenix applications.
 * [canada](https://github.com/jarednorman/canada) - A simple authorization library that provides a friendly interface using declarative permission rules.
 * [canary](https://github.com/cpjk/canary) - An authorization library for Elixir applications that restricts what resources the current user is allowed to access.

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 ## Authorization
 *Libraries for implementing Authorization handling.*
 
-* [authorize](https://github.com/jfrolich/authorize) - Rule based authorization, for advanced authorization rules
+* [authorize](https://github.com/jfrolich/authorize) - Rule based authorization, for advanced authorization rules.
 * [bodyguard](https://github.com/schrockwell/bodyguard) - A flexibile authorization libarary for Phoenix applications.
 * [canada](https://github.com/jarednorman/canada) - A simple authorization library that provides a friendly interface using declarative permission rules.
 * [canary](https://github.com/cpjk/canary) - An authorization library for Elixir applications that restricts what resources the current user is allowed to access.


### PR DESCRIPTION
Resolves #2972

I just published the authorize library that we use in production at our startup. We need some pretty advanced authorization rules, and there was nothing available as a package that could facilitate this. This is the extraction of the code we use, and it really helped us to implement quite sophisticated authorization rules using very readable code.