### PR TITLE
Updating link to exrm_heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,7 +1037,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [exrm](https://github.com/bitwalker/exrm) - Automatically generate a release for your Elixir project.
 * [exrm_deb](https://github.com/johnhamelink/exrm_deb) - Create a deb for your Elixir release with ease.
 * [exrm_docker](https://github.com/kwrooijen/exrm_docker) - Exrm plugin to dockerize your Elixir release.
-* [exrm_heroku](https://github.com/ride/exrm-heroku) - Publish your Elixir releases to Heroku with ease.
+* [exrm_heroku](https://github.com/epsanchezma/exrm-heroku) - Publish your Elixir releases to Heroku with ease.
 * [exrm_rpm](https://github.com/smpallen99/exrm-rpm) - Create a RPM for your Elixir release with ease.
 * [relex](https://github.com/yrashk/relex) - Erlang/Elixir Release Assembler.
 * [renew](https://github.com/Nebo15/renew) - Mix task to create mix projects that builds into Docker containers.


### PR DESCRIPTION
Link currently redirects. Updating link to point at current repo location.