### PR TITLE
Remove toolbox.elixir.pm since it is no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 
 If you think a package should be added, please add a :+1: (`:+1:`) at the according issue or create a new one.
 
-There are other sites with curated lists of elixir packages. Have a look at [toolbox.elixir.pm](http://toolbox.elixir.pm/) and [elixir.libhunt.com](https://elixir.libhunt.com/).
+There are [other sites with curated lists of elixir packages](#other-awesome-lists) which you can have a look at.
 
 - [Awesome Elixir](#awesome-elixir)
     - [Actors](#actors)
@@ -1482,6 +1482,7 @@ Various resources, such as books, websites and articles, for improving your Elix
 ## Other Awesome Lists
 *Other amazingly awesome lists can be found at [jnv/lists](https://github.com/jnv/lists#lists-of-lists) or [bayandin/awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness#awesome-awesomeness).*
 
+* [Awesome Elixir by LibHunt](https://elixir.libhunt.com) - A curated list of awesome Elixir and Erlang packages and resources.
 * [Awesome Erlang](https://github.com/drobakowski/awesome-erlang) - A curated list of awesome Erlang libraries, resources and shiny things.
 * [Erlang Bookmarks](https://github.com/0xAX/erlang-bookmarks) - A collection of links for Erlang developers.
 


### PR DESCRIPTION
I also put [elixir.libhunt.com](https://elixir.libhunt.com/) at the bottom to the other curated lists.