### PR TITLE
Add command line application loki

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 
 * [anubis](https://github.com/bennyhallett/anubis) - Command-Line application framework for Elixir.
 * [getopt](https://github.com/jcomellas/getopt) - Command-line options parser for Erlang.
+* [loki](https://github.com/khusnetdinov/loki) - Library for creating interactive command-line application.
 * [meld](https://github.com/Lac/meld) - Create global binaries from mix tasks.
 * [progress_bar](https://github.com/henrik/progress_bar) - Command-line progress bars and spinners.
 * [table_rex](https://github.com/djm/table_rex) - Generate configurable ASCII style tables for display.


### PR DESCRIPTION
Add Package Loki

Loki is a toolkit for building powerful interactive in "phoenix CLI style"  command-line interfaces.

Resolves "#3375"

Add command line application loki

