### PR TITLE
Remove Nest API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,7 +1319,6 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [mixpanel_data_client](https://github.com/jeregrine/mixpanel_data_client) - Client for interacting with the Mixpanel Data Export API.
 * [mmExchangeRate](https://github.com/Arkar-Aung/mmExchangeRate) - A simple exchange rate checker and calculator based on Central Bank of Myanmar Api.
 * [nadia](https://github.com/zhyu/nadia) - Telegram Bot API Wrapper written in Elixir.
-* [nest](https://github.com/adamzaninovich/nest) - An Elixir library for using the Nest API, allowing integration with Nest Thermostats and other Nest devices.
 * [omise](https://github.com/teerawat1992/omise-elixir) - Omise client library for Elixir.
 * [opbeat](https://github.com/teodor-pripoae/opbeat) - Elixir client for Opbeat.
 * [pagexduty](https://github.com/ride/pagexduty) - A Pagerduty client for Elixir.


### PR DESCRIPTION
This removes the Nest API project from the list:
https://github.com/adamzaninovich/nest

The project is a skeleton project with no functioning Nest code and has not been updated in 2 years.

Make sure you have the following format

##Title

Remove Package "nest"

##Commit message
Remove Package "nest"