### PR TITLE
Removed relisa: the author marked it as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,6 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [exdm](https://github.com/joeyates/exdm) - Deploy Elixir applications via mix tasks.
 * [gatling](https://github.com/hashrocket/gatling) - Collection of mix tasks to automatically create a exrm release from git and launch/upgrade it on your server.
 * [heroku-buildpack-elixir](https://github.com/HashNuke/heroku-buildpack-elixir) - Heroku buildpack to deploy Elixir apps to Heroku.
-* [relisa](https://github.com/SenecaSystems/relisa) - Fast, simple, and composable deployment library for Elixir.
 
 ## Documentation
 *Libraries and tools for creating documentation.*


### PR DESCRIPTION
Some time ago author has marked that relisa is deprecated, see: https://github.com/SenecaSystems/relisa