### PR TITLE
Added a category for feature toggle libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
     - [Errors and Exception Handling](#errors-and-exception-handling)
     - [Eventhandling](#eventhandling)
     - [Examples and funny stuff](#examples-and-funny-stuff)
+    - [Feature Flags and Toggles](#feature-flags-and-toggles)
     - [Feeds](#feeds)
     - [Files and Directories](#files-and-directories)
     - [Formulars](#formulars)
@@ -552,6 +553,14 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [stranger](https://github.com/cazrin/stranger) - Elixir Phoenix app to chat anonymously with a randomly chosen stranger.
 * [weather](https://github.com/tacticiankerala/elixir-weather) - A command line weather app built using Elixir.
 
+## Feature Flags and Toggles
+
+
+* [flippant](https://github.com/sorentwo/flippant) - Feature flipping for the Elixir world.
+* [fun_with_flags](https://github.com/tompave/fun_with_flags) - A feature toggle library using Redis for persistance, ETS for local caching and Redis PubSub for inter-node cache busting. Optimized for speed and low Redis usage.
+* [molasses](https://github.com/securingsincity/molasses) - A feature toggle library using redis or SQL (using Ecto) as a backing service.
+
+
 ## Feeds
 *Libraries working with feeds like RSS or ATOM.*
 
@@ -886,7 +895,6 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [keys1value](https://github.com/okeuday/keys1value) - Erlang set associative map for key lists.
 * [mixgraph](https://github.com/sivsushruth/mixgraph) - An interactive dependency plotter for your Hex Package.
 * [mixstar](https://github.com/ma2gedev/mix-star) - MixStar starred GitHub repository that depends on your project.
-* [molasses](https://github.com/securingsincity/molasses) - A feature toggle library using redis or SQL (using Ecto) as a backing service.
 * [netrc](https://github.com/ma2gedev/netrcex) - Reads netrc files implemented in Elixir.
 * [notifier](https://hex.pm/packages/notifier) - A pluggable architecture for desktop notifications.
 * [onetime](https://github.com/ryo33/onetime-elixir) - An onetime key-value store for Elixir.

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [weather](https://github.com/tacticiankerala/elixir-weather) - A command line weather app built using Elixir.
 
 ## Feature Flags and Toggles
-
+*Libraries to manage feature toggles (AKA feature flags): ON/OFF values that can be toggled at runtime through some interface*
 
 * [flippant](https://github.com/sorentwo/flippant) - Feature flipping for the Elixir world.
 * [fun_with_flags](https://github.com/tompave/fun_with_flags) - A feature toggle library using Redis for persistance, ETS for local caching and Redis PubSub for inter-node cache busting. Optimized for speed and low Redis usage.

--- a/README.md
+++ b/README.md
@@ -560,7 +560,6 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [fun_with_flags](https://github.com/tompave/fun_with_flags) - A feature toggle library using Redis for persistance, ETS for local caching and Redis PubSub for inter-node cache busting. Optimized for speed and low Redis usage.
 * [molasses](https://github.com/securingsincity/molasses) - A feature toggle library using redis or SQL (using Ecto) as a backing service.
 
-
 ## Feeds
 *Libraries working with feeds like RSS or ATOM.*
 


### PR DESCRIPTION
## Feature Flags and Toggles: new category

I've added a new "Feature Flags and Toggles" section to the list.

These two packages have been added:
* `flippant`
* `fun_with_flags` (disclaimer: I'm the author)

Also, the `molasses` library was already present in the "Miscellaneous" section and I've just moved it.

The packages are listed in alphabetic order.

I could find a couple of other libraries serving the same purpose in hex.pm, but I've only included the ones that have proper test coverage and that seem to be maintained.

This PR would solve issues https://github.com/h4cc/awesome-elixir/issues/3780 and https://github.com/h4cc/awesome-elixir/issues/2614.