### PR TITLE
Add package phoenix_gon

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,8 +489,9 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 ## ECMAScript
 *Implementations working with JavaScript, JScript or ActionScript.*
 
-* [estree](https://github.com/bryanjos/elixir-estree) - A implementation of the SpiderMonkey Parser API in Elixir.
 
+* [estree](https://github.com/bryanjos/elixir-estree) - A implementation of the SpiderMonkey Parser API in Elixir.
+* [phoenix_gon](https://github.com/khusnetdinov/phoenix_gon) - Allow you to pass Phoenix environment or controller variables to JavaScript without problems.*
 
 ## Email
 *Working with Email and stuff.*


### PR DESCRIPTION
Add Package "phoenix_gon"

Task was not created, hex published 8 days ago

hex: https://hex.pm/packages/phoenix_gon
github: https://github.com/khusnetdinov/phoenix_gon

PhoenixGon allow you to simply pass `phoenix` and `mix` env variables to JavaScript or browser console. 
