### PR TITLE
Add Package ExGtin to Validation Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1471,6 +1471,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [uk_postcode](https://github.com/KushalP/uk_postcode) - UK postcode parsing and validation library.
 * [vex](https://github.com/CargoSense/vex) - An extensible data validation library for Elixir.
 * [voorhees](https://github.com/danmcclain/voorhees) - A library for validating JSON responses.
+* [ExGtin](https://github.com/kickinespresso/ex_gtin) - A validation library for GTIN codes under GS1 specification.
 
 ## Version Control
 *Working with version control like git, mercury, subversion ...*

--- a/README.md
+++ b/README.md
@@ -1465,13 +1465,13 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 *Libraries and implementations for validation of data.*
 
 * [bankster](https://github.com/railsmechanic/bankster) - A IBAN account number and BIC validation library for Elixir.
+* [ExGtin](https://github.com/kickinespresso/ex_gtin) - A validation library for GTIN codes under GS1 specification.
 * [exop](https://github.com/madeinussr/exop) - A library that allows to encapsulate business logic and validate params with predefined contract.
 * [jeaux](https://github.com/zbarnes757/jeaux) - A light and easy schema validator.
 * [shape](https://github.com/prio/shape) - A data validation library for Elixir based on Prismatic Scheme.
 * [uk_postcode](https://github.com/KushalP/uk_postcode) - UK postcode parsing and validation library.
 * [vex](https://github.com/CargoSense/vex) - An extensible data validation library for Elixir.
 * [voorhees](https://github.com/danmcclain/voorhees) - A library for validating JSON responses.
-* [ExGtin](https://github.com/kickinespresso/ex_gtin) - A validation library for GTIN codes under GS1 specification.
 
 ## Version Control
 *Working with version control like git, mercury, subversion ...*


### PR DESCRIPTION
Adding the new Hex Package [ExGtin](https://github.com/kickinespresso/ex_gtin) to the validation section

Make sure you have the following format

##Title

Add Package ExGtin to Validation Section

##Description

Add Package "ex_gtin" to the Validations Section of the Library

This Library does GTIN code validation. 

GitHub Link: [ExGtin](https://github.com/kickinespresso/ex_gtin) 
HexDocs Link: [ex_gtin](https://www.hex.pm/packages/ex_gtin)

There is no issue number current open. 

##Commit message

Add ex_gtin library
