### PR TITLE
Added `opq`

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,7 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 * [hulaaki](https://github.com/suvash/hulaaki) - An MQTT 3.1.1 client library written in Elixir.
 * [kafka_ex](https://github.com/kafkaex/kafka_ex) - Kafka client library for Elixir.
 * [mqs](https://github.com/synrc/mqs) - RabbitMQ client library, routing keys, RPC over MQ and other stuff.
+* [opq](https://github.com/fredwu/opq) - A simple, in-memory queue with worker pooling and rate limiting in Elixir.
 * [pqueue](https://github.com/okeuday/pqueue) - Erlang Priority Queue Implementation.
 * [queuex](https://github.com/falood/queuex) - Priority Queue with multiple backends.
 * [stream_weaver](https://hex.pm/packages/stream_weaver) - Library for working with streams.


### PR DESCRIPTION
Added `opq` - A simple, in-memory queue with worker pooling and rate limiting in Elixir.