### PR TITLE
Add OAuth2 Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [htpasswd](https://github.com/kevinmontuori/Apache.htpasswd) - Apache htpasswd file reader/writer in Elixir.
 * [mojoauth](https://github.com/mojolingo/mojo-auth.ex) - MojoAuth implementation in Elixir.
 * [oauth2](https://github.com/scrogson/oauth2) - An OAuth 2.0 client library for Elixir.
+* [oauth2_facebook](https://github.com/chrislaskey/oauth2_facebook) - A Facebook OAuth2 Provider for Elixir.
+* [oauth2_github](https://github.com/chrislaskey/oauth2_github) - A GitHub OAuth2 Provider for Elixir.
 * [oauth2cli](https://github.com/mgamini/oauth2cli-elixir) - Simple OAuth2 client written for Elixir.
 * [oauth2ex](https://github.com/parroty/oauth2ex) - Another OAuth 2.0 client library for Elixir.
 * [oauther](https://github.com/lexmag/oauther) - An OAuth 1.0 implementation for Elixir.


### PR DESCRIPTION
Hey there! Thanks for all the hard work y'all put in on maintaining the Awesome Elixir list. It's a big asset to the community.

## Title

This pull request adds two OAuth related packages:

* Add Package [oauth2_facebook](https://github.com/chrislaskey/oauth2_facebook) - A Facebook OAuth2 Provider for Elixir
* Add Package [oauth2_github](https://github.com/chrislaskey/oauth2_github) - A GitHub OAuth2 Provider for Elixir

Both packages have spec coverage, documentation, and are available through Hex.

## Commit message

Add oauth2_facebook and oauth2_github