### PR TITLE
Pkrawat1 gringotts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1410,6 +1410,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [gcmex](https://github.com/dukex/gcmex) - Google Cloud Messaging client library for elixir.
 * [google_sheets](https://github.com/GrandCru/GoogleSheets) - Elixir library for fetching and polling Google spreadsheet data in CSV format.
 * [govtrack](https://github.com/walterbm/govtrack-elixir) - A simple Elixir wrapper for the [govtrack.us](https://www.govtrack.us/developers) API.
+* [gringotts](https://github.com/aviabird/gringotts) -A complete payment library for Elixir and Phoenix Framework.
 * [hexoku](https://github.com/JonGretar/Hexoku) - Heroku API client and Heroku Mix tasks for Elixir projects.
 * [honeywell](https://github.com/jeffutter/honeywell-elixir) - A client for the Honeywell Lyric, Round and Water Leak & Freeze Detector APIs.
 * [kane](https://github.com/peburrows/kane) - A [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/overview) client.

--- a/README.md
+++ b/README.md
@@ -1410,7 +1410,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [gcmex](https://github.com/dukex/gcmex) - Google Cloud Messaging client library for elixir.
 * [google_sheets](https://github.com/GrandCru/GoogleSheets) - Elixir library for fetching and polling Google spreadsheet data in CSV format.
 * [govtrack](https://github.com/walterbm/govtrack-elixir) - A simple Elixir wrapper for the [govtrack.us](https://www.govtrack.us/developers) API.
-* [gringotts](https://github.com/aviabird/gringotts) -A complete payment library for Elixir and Phoenix Framework.
+* [gringotts](https://github.com/aviabird/gringotts) - A complete payment library for Elixir and Phoenix Framework.
 * [hexoku](https://github.com/JonGretar/Hexoku) - Heroku API client and Heroku Mix tasks for Elixir projects.
 * [honeywell](https://github.com/jeffutter/honeywell-elixir) - A client for the Honeywell Lyric, Round and Water Leak & Freeze Detector APIs.
 * [kane](https://github.com/peburrows/kane) - A [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/overview) client.


### PR DESCRIPTION
## Gringotts payments library

Add the Package "Gringotts" from hex.pm
Link: https://hexdocs.pm/gringotts/Gringotts.html
Github: https://github.com/aviabird/gringotts

## Description
Gringotts is a payment gateway integration library supporting many gateway integrations. It is in active development right now, and is trending on github.

Resolves #4377

## Commit message
Adding gringotts library, we just released.  There was a long time requirement for a payment library in elixir community. So we @aviabird thought of creating one.
