### PR TITLE
Add package 'modest_ex'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1564,6 +1564,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [sweet_xml](https://github.com/awetzel/sweet_xml) - Query XML simply and effectively.
 * [xml_builder](https://github.com/joshnuss/xml_builder) - Elixir library for generating xml.
 * [xmlrpc](https://github.com/ewildgoose/elixir-xml_rpc) - Library for encoding and decoding XML-RPC for clients and servers.
+* [modest_ex](https://github.com/f34nk/modest_ex) - A library to do pipeable transformations on html strings with CSS selectors, e.g. find(), prepend(), append(), replace() etc.
 
 ## YAML
 *Libraries and implementations working with YAML.*

--- a/README.md
+++ b/README.md
@@ -1559,12 +1559,12 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [exquery](https://github.com/rozap/exquery) - A library for parsing HTML and querying elements within.
 * [floki](https://github.com/philss/floki) - A simple HTML parser that enables searching using CSS like selectors.
 * [meeseeks](https://github.com/mischov/meeseeks) - A library for parsing and extracting data from HTML and XML with CSS or XPath selectors.
+* [modest_ex](https://github.com/f34nk/modest_ex) - A library to do pipeable transformations on html strings with CSS selectors, e.g. find(), prepend(), append(), replace() etc.
 * [quinn](https://github.com/nhu313/Quinn) - XML parser for Elixir.
 * [readability](https://github.com/keepcosmos/readability) - Readability is for extracting and curating articles.
 * [sweet_xml](https://github.com/awetzel/sweet_xml) - Query XML simply and effectively.
 * [xml_builder](https://github.com/joshnuss/xml_builder) - Elixir library for generating xml.
 * [xmlrpc](https://github.com/ewildgoose/elixir-xml_rpc) - Library for encoding and decoding XML-RPC for clients and servers.
-* [modest_ex](https://github.com/f34nk/modest_ex) - A library to do pipeable transformations on html strings with CSS selectors, e.g. find(), prepend(), append(), replace() etc.
 
 ## YAML
 *Libraries and implementations working with YAML.*


### PR DESCRIPTION
## Title

Add Package "modest_ex"

## Description

**Link:** https://github.com/f34nk/modest_ex

**Description:**

A library to do pipeable transformations on html strings with CSS selectors, e.g. find(), prepend(), append(), replace() etc.

Announcement on the elixirforum: 
https://elixirforum.com/t/modestex-library-to-do-pipeable-transformations-on-html-strings-with-css-selectors/12793

See this issue:
https://github.com/h4cc/awesome-elixir/issues/4415