### PR TITLE
Add `Bunyan: An Elixir Logger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 ## Logging
 *Logging infos and messages.*
 
+* [bunyan](https://github.com/bunyan-logger/bunyan) - Bunyan: An Elixir Logger.
 * [exlager](https://github.com/khia/exlager) - Elixir binding for lager.
 * [exsentry](https://github.com/appcues/exsentry) - Error logging to [Sentry](https://getsentry.com/).
 * [gelf_logger](https://github.com/jschniper/gelf_logger) - A Logger backend that will generate Graylog Extended Log Format (GELF) messages.


### PR DESCRIPTION
`Bunyan: An Elixir Logger` - a distributed `Logger` backend with a lot of thrills by Dave "Pragmatic" Thomas.

## Title

Add Package "Bunyan: An Elixir Logger".

## Commit message

Adding `Bunyan: An Elixir Logger` - a **distributed** `Logger` backend with **a lot** of thrills by (none other than) **Dave "Pragmatic" Thomas**.
