### PR TITLE
add the spandex library for distributed tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [prometheus-plugs](https://github.com/deadtrickster/prometheus-plugs) - Plugs instrumenters/exporter for prometheus.ex.
 * [prometheus.ex](https://github.com/deadtrickster/prometheus.ex) - Elixir-friendly [Prometheus.io](https://prometheus.io) monitoring system and time series database client.
 * [prometheus_process_collector](https://github.com/deadtrickster/prometheus_process_collector) - Prometheus collector which exports the current state of process metrics including cpu, memory, file descriptor usage and native threads count as well as the process start and up times.
+* [spandex](https://github.com/spandex-project/spandex) - Platform agnostic tracing library originally developed for Datadog APM.
 
 ## JSON
 *Libraries and implementations working with JSON.*


### PR DESCRIPTION
## Title

Add Package "spandex"

## Description

Spandex is a handy distributed tracing library that we use in production at https://github.com/teacherspayteachers

## Commit message

A platform agnostic tracing library
