### PR TITLE
Add json_stream_encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [jose](https://github.com/potatosalad/erlang-jose) - JSON Object Signing and Encryption (JOSE) for Erlang and Elixir.
 * [json](https://github.com/cblage/elixir-json) - Native JSON library for Elixir.
 * [json_pointer](https://github.com/xavier/json_pointer) - Implementation of RFC 6901 which defines a string syntax for identifying a specific value within a JSON document.
+* [json_stream_encoder](https://github.com/TreyE/json_stream_encoder) - JsonStreamEncoder is a streaming encoder for streaming JSON to an IOish thing in Elixir.
 * [json_web_token_ex](https://github.com/garyf/json_web_token_ex) - An Elixir implementation of the JSON Web Token (JWT) Standards Track (RFC 7519).
 * [jsonapi](https://github.com/jeregrine/jsonapi) - A project that will render your data models into [JSONAPI Documents](http://jsonapi.org/format/).
 * [jsx](https://github.com/talentdeficit/jsx) - An Erlang application for consuming, producing, and manipulating json.


### PR DESCRIPTION
## Title

Add Package "jsonstream_encoder"

## Description

Resolves #4345 

## Commit message

JsonStreamEncoder is a streaming encoder for streaming JSON to an IOish thing in Elixir.
