### PR TITLE
Move shortuuid to Text and Numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,6 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [elixir_tea](https://github.com/keichan34/elixir_tea) - TEA implementation in Elixir.
 * [ex_bcrypt](https://github.com/manelli/ex_bcrypt) - Elixir wrapper for the OpenBSD bcrypt password hashing algorithm.
 * [ex_crypto](https://github.com/ntrepid8/ex_crypto) - Elixir wrapper for Erlang `crypto` and `public_key` modules. Provides sensible defaults for many crypto functions to make them easier to use.
-* [ex_shortuuid](https://github.com/gpedic/ex_shortuuid) - Simple library that generates concise, unambiguous, URL-safe UUIDs.
 * [exgpg](https://github.com/rozap/exgpg) - Use gpg from Elixir.
 * [ntru_elixir](https://github.com/alisinabh/ntru_elixir) - Elixir wrapper for libntru. A post quantum cryptography system.
 * [one_time_pass_ecto](https://github.com/riverrun/one_time_pass_ecto) - One-time password library for Elixir.
@@ -1449,6 +1448,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [remove_emoji](https://github.com/guanting112/elixir_remove_emoji) - Emoji text sanitizer in Elixir. It can remove any emoji symbol.
 * [secure_random](https://github.com/patricksrobertson/secure_random.ex) - Convenience library for random base64 strings modeled after my love for Ruby's SecureRandom.
 * [sentient](https://github.com/dantame/sentient) - Simple sentiment analysis based on the AFINN-111 wordlist.
+* [shortuuid](https://github.com/gpedic/ex_shortuuid) - Generate concise, unambiguous, URL-safe UUIDs.
 * [simetric](https://github.com/lexmag/simetric) - String similarity metrics for Elixir.
 * [slugger](https://github.com/h4cc/slugger) - Slugger can generate slugs from given strings that can be used in URLs or file names.
 * [stemmer](https://github.com/fredwu/stemmer) - An English (Porter2) stemming implementation in Elixir.


### PR DESCRIPTION
I would just like to move shortuuid from `Cryptography` to `Text and Numbers` as it is a tool to encode UUIDs and all encoding and UUID libs are under that category.

Also changed the name from `ex_shortuuid` to `shortuuid`, the actual package name.

Cheers