### PR TITLE
Add ecto_shortuuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1113,6 +1113,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [ecto_paging](https://github.com/Nebo15/ecto_paging) - Cursor-based pagination for Ecto.
 * [ecto_rut](https://github.com/sheharyarn/ecto_rut) - Simple and Powerful Ecto Shortcuts to simplify and speed up development.
 * [ecto_shortcuts](https://github.com/MishaConway/ecto_shortcuts) - Shortcuts for common operations in ecto.
+* [ecto_shortuuid](https://github.com/gpedic/ecto_shortuuid) - Ecto type which adds support for [ShortUUIDs](https://github.com/gpedic/ex_shortuuid).
 * [ecto_validation_case](https://github.com/danielberkompas/ecto_validation_case) - Simplify your Ecto model validation tests. Loosely inspired by shoulda matchers, but simpler.
 * [ectophile](https://github.com/gjaldon/ectophile) - Ecto extension to instantly support file uploads in models.
 * [elastic](https://github.com/radar/elastic) - A thin-veneer over HTTPotion to help you talk to Elastic Search.


### PR DESCRIPTION
## Title

Add Package "ecto_shortuuid"

## Commit message

Ecto type which adds support for [ShortUUIDs](https://github.com/gpedic/ex_shortuuid).

ecto_shortuuid builds on shortuuid added in #4548 by making it simple to use shortuuid as field types
