### PR TITLE
link updated to reflect moved project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 ## Cloud Infrastructure and Management
 *Applications, tools and libraries for your own cloud service.*
 
-* [aws](https://github.com/jkakar/aws-elixir) - AWS clients for Elixir.
+* [aws](https://github.com/aws-beam/aws-elixir) - AWS clients for Elixir.
 * [Bonny](https://github.com/coryodaniel/bonny) - Kubernetes Operator Development Framework.
 * [Cloudi](http://cloudi.org/) - CloudI is for back-end server processing tasks that require soft-realtime transaction.
 * [discovery](https://github.com/undeadlabs/discovery) - An OTP application for auto-discovering services with Consul.


### PR DESCRIPTION


## Title

Change Link to Package, "AWS Clients for Elixir"

## Description

No formal issue

## Commit message

Previously linked to project with readme that said, "This project has moved to https://github.com/aws-beam/aws-elixir"