### PR TITLE
Add Dummy (#4581)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1335,6 +1335,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [chemistry](https://github.com/genericlady/chemistry) - Testing Framework for Elixir.
 * [cobertura_cover](https://github.com/PSPDFKit-labs/cobertura_cover) - Writes a coverage.xml from `mix test --cover` file compatible with Jenkins' Cobertura plugin.
 * [double](https://github.com/sonerdy/double) - Create stub dependencies for testing without overwriting global modules.
+* [dummy](https://github.com/Vesuvium/dummy) - An Elixir mocking library that makes sense by exposing meck in the right way 
 * [ecto_it](https://github.com/xerions/ecto_it) - Ecto plugin with default configuration for repos for testing different ecto plugins with databases.
 * [efrisby](https://github.com/FabioBatSilva/efrisby) - A REST API testing framework for erlang.
 * [elixir-auto-test](https://github.com/joaothallis/elixir-auto-test) - Run test when file is saved using inotify-tools.


### PR DESCRIPTION
## Title

Add Package "dummy"

## Description

Resolves #4581 

## Commit message

Elixir mocking that makes sense. Dummy relies on meck and exposes a simple way to mock methods, thanks to a couple of assumptions
