### PR TITLE
Fix typos in exsms description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,7 +1289,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 ## SMS
 *SMS related libraries and tools.*
 
-* [exsms](https://hex.pm/packages/exsms) - A Elixir library for sending transactional SMS - supoprts Sendinblue, mailjet ,msg91 and textlocal.
+* [exsms](https://hex.pm/packages/exsms) - An Elixir library for sending transactional SMS - supports Sendinblue, mailjet, msg91 and textlocal.
 
 ## Static Page Generation
 *Tools and libraries for generating static websites and content.*


### PR DESCRIPTION
Found a few typos in exsms package description.
