### PR TITLE
exquery is deprecated in favor of meseeks

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,9 +801,9 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 ## HTML
 *Libraries and implementations working with HTML (for xml tools please go to the [XML](#xml) section).*
 
-* [exquery](https://github.com/rozap/exquery) - A library for parsing HTML and querying elements within.
 * [floki](https://github.com/philss/floki) - A simple HTML parser that enables searching using CSS like selectors.
 * [html_sanitize_ex](https://github.com/rrrene/html_sanitize_ex) - HTML sanitizer for Elixir.
+* [meseeks](https://github.com/mischov/meeseeks) - A library for parsing and extracting data from HTML and XML with CSS or XPath selectors.
 * [modest_ex](https://github.com/f34nk/modest_ex) - A library to do pipeable transformations on html strings with CSS selectors, e.g. find(), prepend(), append(), replace() etc.
 * [myhtmlex](https://github.com/Overbryd/myhtmlex) - Elixir/Erlang bindings for lexborisov's myhtml.
 * [readability](https://github.com/keepcosmos/readability) - Readability is for extracting and curating articles.


### PR DESCRIPTION
## Title

Add Package "meseeks"
Remove Package "exquery"

## Description

Per the readme of exquery, it should be replaced with meseeks:
https://github.com/rozap/exquery/blob/master/README.md

## Commit message

meseeks is a library for parsing and extracting data from HTML and XML with CSS or XPath selectors.