### PR TITLE
Add open_hours package

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [jalaali](https://github.com/jalaali/elixir-jalaali) - Jalaali calendar implementation for Elixir.
 * [milliseconds](https://github.com/davebryson/elixir_milliseconds) - Simple library to work with milliseconds in Elixir.
 * [moment](https://github.com/atabary/moment) - Parse, validate, manipulate, and display dates in Elixir.
+* [open_hours](https://github.com/hopsor/open_hours) - Time calculations using business hours.
 * [quantum](https://github.com/c-rack/quantum-elixir) - Cron-like job scheduler for Elixir applications.
 * [repeatex](https://github.com/rcdilorenzo/repeatex) - Natural language parsing for repeating dates.
 * [tiktak](https://github.com/ConduitMobileRND/tiktak) - Fast and lightweight web scheduler written in Elixir.


### PR DESCRIPTION
## Title

Add Package "open_hours"

## Commit message

This package helps calculating when a business is open or closed based on a schedule that you can set up with the day open times, holidays, special dates and shifts. It's inspired by Zendesk's biz ruby gem.