### PR TITLE
Updated Quantum repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [milliseconds](https://github.com/davebryson/elixir_milliseconds) - Simple library to work with milliseconds in Elixir.
 * [moment](https://github.com/atabary/moment) - Parse, validate, manipulate, and display dates in Elixir.
 * [open_hours](https://github.com/hopsor/open_hours) - Time calculations using business hours.
-* [quantum](https://github.com/c-rack/quantum-elixir) - Cron-like job scheduler for Elixir applications.
+* [quantum](https://github.com/quantum-elixir/quantum-core) - Cron-like job scheduler for Elixir applications.
 * [repeatex](https://github.com/rcdilorenzo/repeatex) - Natural language parsing for repeating dates.
 * [tiktak](https://github.com/ConduitMobileRND/tiktak) - Fast and lightweight web scheduler written in Elixir.
 * [timelier](https://github.com/ausimian/timelier) - A cron-style scheduler for Elixir.


### PR DESCRIPTION
Updated Quantum dependency repository URL.  
Previous repo was archived and move to the organisation.