### PR TITLE
Add Classpert Elixir Online Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1835,6 +1835,7 @@ Various resources, such as books, websites and articles, for improving your Elix
 * [Hashrocket Today I Learned - Elixir](https://til.hashrocket.com/elixir) - Small posts about Elixir from the team at Hashrocket.
 * [How I start - Elixir](http://howistart.org/posts/elixir/1) - Explanation and intro to Elixir by José Valim.
 * [Learning Elixir](http://learningelixir.joekain.com/) - A blog about a Professional Software Engineer learning Elixir.
+* [Elixir Online Courses list - Classpert](https://classpert.com/elixir-programming) - A list of Elixir Online Courses (some are free) from Classpert Online Course Search
 
 # Contributing
 Please see [CONTRIBUTING](https://github.com/h4cc/awesome-elixir/blob/master/.github/CONTRIBUTING.md) for details.


### PR DESCRIPTION
This commit adds Classpert to the "Websites" section, containing around 20 Elixir Online Courses.

## Title

Add Package "name-of-the-package"

## Description

Resolves #issue-number

## Commit message

A short description of the package
