### PR TITLE
Add telegex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1609,6 +1609,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [stripe](https://github.com/SenecaSystems/stripe) - An Elixir Library wrapping Stripe's API.
 * [stripity_stripe](https://github.com/robconery/stripity-stripe) - An Elixir Library for [Stripe](https://stripe.com/).
 * [tagplay](https://github.com/tagplay/elixir-tagplay) - Elixir client for Tagplay API.
+* [telegex](https://github.com/Hentioe/telegex) - Telegram bot library for Elixir.
 * [telephonist](https://github.com/danielberkompas/telephonist) - Elixir state machines for Twilio calls.
 * [tentacat](https://github.com/edgurgel/tentacat) - Simple Elixir wrapper for the GitHub API.
 * [tg_client](https://github.com/ccsteam/ex-telegram-client) - An Elixir wrapper which communicates with the Telegram-CLI.


### PR DESCRIPTION
## Title

Add Package "telegex"

## Description

Resolves #4701

## Commit message

This is a library for building bot applications on the Telegram platform, and the main maintainer is myself.

[Some introductions to it on the official forum](https://elixirforum.com/t/telegex-telegram-bot-library-full-support-for-the-latest-api-versions).

Package link: https://hex.pm/packages/telegex