### PR TITLE
Add Xcribe into Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [maru_swagger](https://github.com/falood/maru_swagger) - Add swagger compliant documentation to your maru API.
 * [phoenix_api_docs](https://github.com/smoku/phoenix_api_docs) - Generate API Blueprint documentation from controllers and tests in the Phoenix framework.
 * [phoenix_swagger](https://github.com/xerions/phoenix_swagger) - Provides swagger integration to the Phoenix framework.
+* [xcribe](https://github.com/brainn-co/xcribe) - Generate API documentation from tests using Swagger (OpenAPI) or API Blueprint specification.
 
 ## Domain-specific language
 *Specialized computer languages for a particular application domain.*


### PR DESCRIPTION
## Title

Add Package "xcribe"

## Description

Resolves #issue-number

## Commit message

Xcribe is a doc generator for Rest APIs built with Phoenix. The documentation is generated by the tests.

Currently API Blueprint and Swagger (OpenAPI Spec 3.0) specifications are supported.