### PR TITLE
Add Calixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 
 * [block_timer](https://github.com/adamkittelson/block_timer) - Macros to use :timer.apply_after and :timer.apply_interval with a block.
 * [calendar](https://github.com/lau/calendar) - Calendar is a date and time library for Elixir.
+* [calixir](https://github.com/rengel-de/calixir) - Calixir is a port of the Lisp calendar software calendrica-4.0 to Elixir.
 * [chronos](https://github.com/nurugger07/chronos) - An Elixir date/time library.
 * [cocktail](https://github.com/peek-travel/cocktail) - Elixir date recurrence library based on iCalendar events.
 * [cronex](https://github.com/jbernardo95/cronex) - Cron like system you can mount in your supervision tree.


### PR DESCRIPTION
## Title

Add Package "Calixir"

## Description

Resolves #4706 

## Commit message

Calixir is a port of the Lisp calendar software calendrica-4.0 to Elixir.

Package link: https://hex.pm/packages/calixir
