### PR TITLE
Added a WebAssembly category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1716,7 +1716,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [silent_video](https://github.com/talklittle/silent_video) - Convert GIFs and videos to silent videos, optimized for mobile playback.
 
 ## WebAssembly
-*Libraries for running WebAssembly (WASM) in Elixir or running Elixir an WebAssembly.*
+*Libraries for running WebAssembly (WASM) in Elixir or running Elixir on WebAssembly.*
 
 * [lumen](https://github.com/lumen/lumen) - An alternative BEAM implementation, designed for WebAssembly.
 * [wasmex](https://github.com/tessi/wasmex/) - Execute WebAssembly / WASM binaries from Elixir.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
     - [Validations](#validations)
     - [Version Control](#version-control)
     - [Video](#video)
+    - [WebAssembly](#web-assembly)
     - [XML](#xml)
     - [YAML](#yaml)
 - [Resources](#resources)
@@ -1713,6 +1714,12 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 
 * [ffmpex](https://github.com/talklittle/ffmpex) - FFmpeg command line wrapper.
 * [silent_video](https://github.com/talklittle/silent_video) - Convert GIFs and videos to silent videos, optimized for mobile playback.
+
+## WebAssembly
+*Libraries for running WebAssembly (WASM) in Elixir or running Elixir an WebAssembly.*
+
+* [lumen](https://github.com/lumen/lumen) - An alternative BEAM implementation, designed for WebAssembly.
+* [wasmex](https://github.com/tessi/wasmex/) - Execute WebAssembly / WASM binaries from Elixir.
 
 ## XML
 *Libraries and implementations working with XML (for html tools please go to the [HTML](#html) section).*


### PR DESCRIPTION
This commit adds WebAssembly as a new category of things. It proposes two entries: `lumen` and `wasmex`. I am currently not aware of more WASM related projects (which are still maintained).

Disclaimer: I'm the author of wasmex