### PR TITLE
Add ConfigCat Elixir SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 ## Feature Flags and Toggles
 *Libraries to manage feature toggles (AKA feature flags): ON/OFF values that can be toggled at runtime through some interface*
 
+* [ConfigCat](https://github.com/configcat/elixir-sdk) - Elixir SDK for ConfigCat hosted feature flag service.
 * [flippant](https://github.com/sorentwo/flippant) - Feature flipping for the Elixir world.
 * [fun_with_flags](https://github.com/tompave/fun_with_flags) - A feature toggle library using Redis or Ecto for persistence, an ETS cache for speed and PubSub for distributed cache busting. Comes with a management web UI for Phoenix and Plug.
 * [molasses](https://github.com/securingsincity/molasses) - A feature toggle library using redis or SQL (using Ecto) as a backing service.


### PR DESCRIPTION
Add link to ConfigCat's Elixir SDK. ConfigCat is a hosted feature flag service.

<!--
Before submitting your pull request, please read the contributing guidelines:
https://github.com/h4cc/awesome-elixir/blob/master/.github/CONTRIBUTING.md
-->
