### PR TITLE
Update kafka libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,8 +1290,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [heapq](https://github.com/takscape/elixir-heapq) - A Heap-based Priority Queue Implementation in Elixir.
 * [honeydew](https://github.com/koudelka/honeydew) - Honeydew is a worker pool library for Elixir.
 * [hulaaki](https://github.com/suvash/hulaaki) - An MQTT 3.1.1 client library written in Elixir.
-* [kafka_consumer](https://github.com/anoskov/kafka-consumer) - Consumer for Kafka using kafka_ex.
-* [kafka_ex](https://github.com/kafkaex/kafka_ex) - Kafka client library for Elixir.
+* [kaffe](https://github.com/spreedly/kaffe) - Kafka client library for Elixir.
 * [mqs](https://github.com/synrc/mqs) - RabbitMQ client library, routing keys, RPC over MQ and other stuff.
 * [oban](https://github.com/sorentwo/oban) - Robust asynchronous job processor powered by Elixir and modern PostgreSQL.
 * [opq](https://github.com/fredwu/opq) - A simple, in-memory queue with worker pooling and rate limiting in Elixir.


### PR DESCRIPTION
This PR aims to change Kafka recommended libraries once the current Kafka lib [kafka_ex](https://github.com/kafkaex/kafka_ex) does not provides basic authentication mechanisms to connect to Kafka like SASL. Most of Kafka clusters have this type of authentication and developers can fall in the mistake of start their development with a library that does not accounts such a basic feature.

Based on that I would like to suggest the replace it by [kaffe](https://github.com/spreedly/kaffe).
