### PR TITLE
Added sise into Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [mac](https://github.com/ephe-meral/mac) - Can be used to find a vendor of a MAC given in hexadecimal string (according to IEEE).
 * [pool](https://github.com/slogsdon/pool) - Socket acceptor pool for Elixir.
 * [reagent](https://github.com/meh/reagent) - reagent is a socket acceptor pool for Elixir.
+* [sise](https://github.com/aytchell/sise) - A simple to use SSDP client.
 * [sockerl](https://github.com/Pouriya-Jahanbakhsh/sockerl) - Sockerl is an advanced Erlang/Elixir socket library for TCP protocols and provides fast, useful and easy-to-use API for implementing servers, clients and client connection pools.
 * [socket](https://github.com/meh/elixir-socket) - Socket wrapping for Elixir.
 * [sshex](https://github.com/rubencaro/sshex) - Simple SSH helpers for Elixir.


### PR DESCRIPTION
**sise** is a simple to use SSDP client (Simple Service Discovery Protocol; which is the "service discovery" part of UPnP)

The implementation is compatible with the UPnP 2.0 spec. Users of the application can either manually `get(...)` the found services and devices or `subscribe(...)` to be notified.

**Documentation:** https://hexdocs.pm/sise/Sise.html
**Hex:** https://hex.pm/packages/sise
**Github:** https://github.com/aytchell/sise