### PR TITLE
Add package indicado

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,6 +1068,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [hammer](https://github.com/ExHammer/hammer) - A rate-limiter with pluggable storage backends, including Redis.
 * [html_entities](https://github.com/martinsvalin/html_entities) - Elixir module for decoding HTML entities in a string.
 * [huex](https://github.com/xavier/huex) - Elixir client for Philips Hue connected light bulbs.
+* [indicado](https://github.com/thisiscetin/indicado) - Technical indicator library for Elixir with no dependencies.
 * [japan_municipality_key](https://github.com/hykw/japan_municipality_key) - Elixir Library for Japan municipality key converting.
 * [Jisho-Elixir](https://github.com/nbw/jisho_elixir) - An API wrapper for Jisho.org, an online Japanese dictionary. Allows users to search by word, symbol, and or tags (refer to docs).
 * [keys1value](https://github.com/okeuday/keys1value) - Erlang set associative map for key lists.


### PR DESCRIPTION
A technical indicator library for Elixir with no dependencies.

We see crypto trading bot projects both open/closed source [being developed](https://www.elixircryptobot.com) with Elixir as the language is a great fit every other day. This library aims to improve trading decisions by integrating technical indicators into those systems.

In addition to crypto, stock market data, the indicators covered in the [indicado library](https://github.com/thisiscetin/indicado) can be used in many numerical data sets.

I would be very happy if you include my library to your list, thank you.