### PR TITLE
Add m2cgen for transpiling ML models into Elixir code

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 *When your code becomes smarter than you.*
 
 * [Exnn](https://github.com/zampino/exnn) - Evolutive Neural Networks framework à la G.Sher written in Elixir. ([Docs](http://zampino.github.io/exnn/)).
+* [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Elixir code with zero dependencies.
 * [Neat-Ex](https://gitlab.com/onnoowl/Neat-Ex) - An Elixir implementation of the NEAT algorithm. ([Docs](https://hexdocs.pm/neat_ex/Neat.html)).
 * [Runhyve](https://runhyve.app) - Runhyve is complete virtual machines manager for bhyve on FreeBSD. It's written in Elixir and uses Phoenix framework.
 * [simple_bayes](https://github.com/fredwu/simple_bayes) - A Simple Bayes / Naive Bayes implementation in Elixir.


### PR DESCRIPTION
Hey there! Thanks a lot for this list!

I'm not sure whether this contribution fits the project ideology 100% or not. `m2cgen` is **not written** in Elixir but **generates** Elixir code. It is a lightweight library with command line interface which allows to transpile trained machine learning models into a native code of Elixir programming language. Examples of generated Elixir code can be found [here](https://github.com/BayesWitnesses/m2cgen/tree/master/generated_code_examples/elixir).

Thanks a lot for your time and consideration!