### PR TITLE
Add Matcha library to OTP libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1244,6 +1244,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [erlexec](https://github.com/saleyn/erlexec) - Execute and control OS processes from Erlang/OTP.
 * [immortal](https://github.com/danielberkompas/immortal) - Immortal is a small collection of helper modules intended to make it easier to build a fault-tolerant OTP application.
 * [libex_config](https://github.com/reset/libex-config) - Helpers for accessing OTP application configuration.
+* [matcha](https://github.com/christhekeele/matcha) - First-class match specifications for Elixir.
 
 ## Package Management
 *Libraries and tools for package and dependency management.*


### PR DESCRIPTION
Matcha is a library that helps alchemists work with OTP's [match specifications](https://www.erlang.org/doc/apps/erts/match_spec.html) in a much more intuitive fashion.

Library is well-documented, well-tested, and in active development by myself, preparing for a new release soon.