### PR TITLE
Add Flowbite library with Phoenix/Elixir integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [RIG](https://github.com/Accenture/reactive-interaction-gateway) - Create low-latency, interactive user experiences for stateless microservices.
 * [sugar](https://github.com/sugar-framework/sugar) - Modular web framework for Elixir.
 * [trot](https://github.com/hexedpackets/trot) - An Elixir web micro-framework.
+* [Flowbite](https://flowbite.com/docs/getting-started/phoenix/) - An open-source UI component library built with Tailwind CSS and compatible with Phoenix/Elixir.
 
 ## Games
 *Libraries for and implementations of games.*

--- a/README.md
+++ b/README.md
@@ -814,6 +814,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 *Web development frameworks.*
 
 * [exelli](https://github.com/pigmej/exelli) - An Elli Elixir wrapper with some sugar syntax goodies.
+* [Flowbite](https://flowbite.com/docs/getting-started/phoenix/) - An open-source UI component library built with Tailwind CSS and compatible with Phoenix/Elixir.
 * [kitto](https://github.com/kittoframework/kitto) - A framework for interactive dashboards.
 * [n2o](https://github.com/synrc/n2o) - Distributed Application Server.
 * [nitro](https://github.com/synrc/nitro) - Nitrogen-compatible Web Framework.
@@ -825,7 +826,6 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [RIG](https://github.com/Accenture/reactive-interaction-gateway) - Create low-latency, interactive user experiences for stateless microservices.
 * [sugar](https://github.com/sugar-framework/sugar) - Modular web framework for Elixir.
 * [trot](https://github.com/hexedpackets/trot) - An Elixir web micro-framework.
-* [Flowbite](https://flowbite.com/docs/getting-started/phoenix/) - An open-source UI component library built with Tailwind CSS and compatible with Phoenix/Elixir.
 
 ## Games
 *Libraries for and implementations of games.*


### PR DESCRIPTION
Hey @h4cc,

Thanks for this awesome resource! I'm one of the open-source contributors to the Flowbite UI library and we have recently built an integration guide for [Phoenix Framework (Elixir)](https://flowbite.com/docs/getting-started/phoenix/) and it works quite well! Luckily, the underlying CSS framework is also Tailwind CSS which means it's nicely in line with the latest 1.7 version of Phoenix.

I though it would be nice to also have a UI library in this list that is compatible or at least has an extensive integration guide. Hopefully I have adhered to all contribution guidelines and I believe it's better to link to the integration guide directly rather than the full package because it's a bit more general-use.

Cheers,
Zoltan