### PR TITLE
Add mahaul library

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [hush](https://github.com/gordalina/hush) - Read and inject configuration at runtime, and in release mode with support for multiple providers.
 * [hush_aws_secrets_manager](https://github.com/gordalina/hush_aws_secrets_manager) - AWS Secrets Manager provider for hush.
 * [hush_gcp_secret_manager](https://github.com/gordalina/hush_gcp_secret_manager) - Google Secret Manager provider for hush.
+* [mahaul](https://github.com/emadalam/mahaul) - Supercharge your environment variables in Elixir. Parse and validate with compile time access guarantees, defaults, fallbacks and app pre-boot validations.
 * [skogsra](https://github.com/gmtprime/skogsra) - Library to manage OS environment variables and application configuration options with ease
 * [sweetconfig](https://github.com/d0rc/sweetconfig) - Read YAML configuration files from any point at your app.
 * [weave](https://gitlab.com/gt8/open-source/elixir/weave) - JIT configuration loader that works with Kubernetes and Docker Swarm.


### PR DESCRIPTION
<!--
Before submitting your pull request, please read the contributing guidelines:
https://github.com/h4cc/awesome-elixir/blob/master/.github/CONTRIBUTING.md
-->
Adds [mahaul](https://github.com/emadalam/mahaul), a one of a kind library to access environment variables in Elixir.

Resolves #4832 