### PR TITLE
Fix link to WebAssembly category

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
     - [Validations](#validations)
     - [Version Control](#version-control)
     - [Video](#video)
-    - [WebAssembly](#web-assembly)
+    - [WebAssembly](#webassembly)
     - [XML](#xml)
     - [YAML](#yaml)
 - [Resources](#resources)


### PR DESCRIPTION
This PR fixes the link to the WebAssembly category in order to enable navigation to the correct section in the README.

<!--
Before submitting your pull request, please read the contributing guidelines:
https://github.com/h4cc/awesome-elixir/blob/master/.github/CONTRIBUTING.md
-->
