### PR TITLE
Add Enum cheatsheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1889,6 +1889,7 @@ Various resources, such as books, websites and articles, for improving your Elix
 *Useful Elixir-related cheat sheets.*
 
 * [benjamintanweihao/elixir-cheatsheets](https://github.com/benjamintanweihao/elixir-cheatsheets/) - GenServer and Supervisor cheatsheets.
+* [elixir-lang/elixir](https://hexdocs.pm/elixir/main/enum-cheat.html) - Enum cheatsheets.
 
 ## Community
 *Getting in contact with the community via chat or mailinglist.*


### PR DESCRIPTION
### What

Elixir 1.6 version introduced new concept of cheatsheets in exdocs. As a first cheatsheet they implemented it for Enum and this PR puts a proper link in a README file.