### PR TITLE
Add Elixir Merge under newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1930,6 +1930,7 @@ Various resources, such as books, websites and articles, for improving your Elix
 *Useful Elixir-related newsletters.*
 
 * [Elixir Digest](http://elixirdigest.net) - A weekly newsletter with the latest articles on Elixir and Phoenix.
+* [Elixir Merge](https://elixirmerge.com) - A daily newsletter which delivers two curated updates (articles, tutorials, videos, podcasts) in each edition in quick-read format.
 * [Elixir Radar](http://plataformatec.com.br/elixir-radar) - The "official" Elixir newsletter, published weekly via email by Plataformatec.
 * [ElixirWeekly](https://elixirweekly.net) - The Elixir community newsletter, covering stuff you easily miss, shared on [ElixirStatus](http://elixirstatus.com) and the web.
 


### PR DESCRIPTION
Update [Newsletters](https://github.com/h4cc/awesome-elixir/tree/master#newsletters) section to add [Elixir Merge](https://elixirmerge.com/) newsletter.
Elixir Merge is a newsletter that delivers the best of the Elixir community in just two curated updates, featuring news, tutorials, videos, podcasts, and blog posts. Perfect for busy developers who want to know what matters without the overwhelm.

References:
- [https://elixirmerge.com/](https://elixirmerge.com/)
- [Elixir Forum | We started a daily Elixir Newsletter - Elixir Merge](https://elixirforum.com/t/we-started-a-daily-elixir-newsletter-elixir-merge/58525?u=akshayrathod)

