### PR TITLE
Add libsqlex (unofficial libsql database driver for elixir)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1252,6 +1252,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [kalecto](https://github.com/lau/calecto) - Glue between Kalends and Ecto for saving dates, times and datetimes.
 * [kvs](https://github.com/synrc/kvs) - Erlang Abstract Term Database.
 * [level](https://github.com/gausby/level) - Level for Elixir implements various helper functions and data types for working with Googles Level data store.
+* [libsqlex](https://github.com/danawanb/libsqlex) - Libsql driver for Elixir.
 * [mariaex](https://github.com/xerions/mariaex) - MariaDB/MySQL driver for Elixir.
 * [memento](https://github.com/sheharyarn/memento) - Simple Mnesia Interface in Elixir.
 * [moebius](https://github.com/robconery/moebius) - A functional query tool for Elixir and PostgreSQL.


### PR DESCRIPTION
This adds Libsql database driver that I have recently published.