### PR TITLE
Add LlmComposer to Artificial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [Exnn](https://github.com/zampino/exnn) - Evolutive Neural Networks framework à la G.Sher written in Elixir. ([Docs](http://zampino.github.io/exnn/)).
 * [GenAI](https://github.com/noizu-labs-ml/genai) - An extensible Generative AI Completion API Wrapper with basic chat completion with tool use support provided for Gemini, Anthropic, OpenAI, and Mistral models. ([Docs](https://hexdocs.pm/genai/GenAI.html)).
 * [Jido](https://github.com/agentjido/jido) - Autonomous agent framework for Elixir. Built for distributed, autonomous behavior and dynamic workflows.
+* [LlmComposer](https://github.com/doofinder/llm_composer) - Elixir library that simplifies interaction with large language models (LLMs) such as OpenAI, OpenRouter, Ollama, Bedrock, and Google Gemini.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Elixir code with zero dependencies.
 * [Neat-Ex](https://gitlab.com/onnoowl/Neat-Ex) - An Elixir implementation of the NEAT algorithm. ([Docs](https://hexdocs.pm/neat_ex/Neat.html)).
 * [Noizu-OpenAi](https://github.com/noizu-labs/elixir-openai) - An Elixir Api for the OpenAI Library. ([Docs](https://hexdocs.pm/noizu_labs_open_ai/api-reference.html)).


### PR DESCRIPTION
Add LlmComposer library to the Artificial Intelligence section.

LlmComposer is a hex-installable, tested, and documented Elixir library for
interacting with LLMs (OpenAI, OpenRouter, Ollama, Bedrock, Google Gemini).

- https://github.com/doofinder/llm_composer
- https://hex.pm/packages/llm_composer