### PR TITLE
Add Livellm to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [ExShop](https://github.com/authentic-pixels/ex-shop) - Digital goods shop & blog created using Phoenix framework.
 * [Harpoon](https://github.com/aschiavon91/harpoon) - A webhook receiver/inspector app, made using Phoenix and LiveView, it's basically a simplified version of [webhook.site](htts://webhook.site).
 * [Igthorn](https://github.com/cinderella-man/igthorn) - Cryptocurrecy trading platform / trading bot with admin panel.
+* [Livellm](https://github.com/sonic182/livellm) - A minimal Phoenix LiveView chat app demonstrating multi-provider LLM streaming, cost tracking, and stateful conversation using llm_composer.
 * [Lynx](https://github.com/clivern/lynx) - A Fast, Secure and Reliable Terraform Backend, Set up in Minutes.
 * [majremind](https://bitbucket.org/Anwen/majremind) - A self-maintained database of your updated server which tells you which one needs to be updated.
 * [medex](https://github.com/xerions/medex) - Medical Examination - application for register health check callbacks and represent their state via HTTP.


### PR DESCRIPTION
  Add Livellm to the Applications section.

  Livellm is a minimal Phoenix LiveView chat app that serves as a working
  reference for integrating llm_composer. It demonstrates multi-provider
  LLM streaming, reasoning output, token cost tracking, and stateful
  conversation using standard Elixir/OTP and Phoenix LiveView patterns.

  - https://github.com/sonic182/livellm